### PR TITLE
Add armhf build to the GH actrions workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,13 +11,15 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v4
       - run: nix-build ./hack/docker.nix -o docker-amd64
       - run: nix-build ./hack/docker.nix --arg pkgs '(import ./hack/nixpkgs.nix {}).pkgsCross.aarch64-multiplatform' -o docker-arm64
+      - run: nix-build ./hack/docker.nix --arg pkgs '(import ./hack/nixpkgs.nix {}).pkgsCross.aarch64-multiplatform' -o docker-armhf
       - run: |
           nix run -f ./hack/nixpkgs.nix pkgs.buildah<<EOF
           buildah manifest create origin-ca-issuer
           buildah manifest add origin-ca-issuer docker-archive:./docker-amd64
           buildah manifest add origin-ca-issuer docker-archive:./docker-arm64
+          buildah manifest add origin-ca-issuer docker-archive:./docker-armhf
           buildah manifest inspect origin-ca-issuer
-          buildah manifest push --all --creds ${DOCKER_HUB_USERNAME}:${DOCKER_HUB_TOKEN} -f v2s2 origin-ca-issuer docker://cloudflare/origin-ca-issuer:${GITHUB_REF#refs/tags/}
+          buildah manifest push --all --creds ${DOCKER_HUB_USERNAME}:${DOCKER_HUB_TOKEN} -f v2s2 origin-ca-issuer docker://mcdermg/origin-ca-issuer:${GITHUB_REF#refs/tags/}
           EOF
         env:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 result
 result-*
 .envrc
+**.swp


### PR DESCRIPTION
When trying to install on older moldels of the Raspberry pi
running 32 bit OS requires a different docker build to produce a
compatible container. Forked and tried to update the workfl;ow so that
it will create an additional Docker image for this and pusgh to my own,
mcdermg, dokcher hub repo.

Also added ignore .swp files to .gitignore as dont want them showing up
while editing.